### PR TITLE
Support nonstandard attributes

### DIFF
--- a/src/harmaja.test.tsx
+++ b/src/harmaja.test.tsx
@@ -26,6 +26,12 @@ describe("Harmaja", () => {
         expect(() => <span id="x" ref="not-a-function"/>).toThrow("Expecting ref prop to be a function, got not-a-function")
     })
 
+    it("Supports assigning standard and nonstandard attributes", () => {
+        let span = <span draggable={true} data-test="my-test-id">Hello</span>
+        mount(span, body())
+        expect(renderAsString(span)).toEqual('<span draggable="true" data-test="my-test-id">Hello</span>')
+    })
+
     it("Creating elements with JSX", () => {
         const el = <h1>yes</h1>
         expect(renderAsString(el)).toEqual("<h1>yes</h1>")

--- a/src/harmaja.ts
+++ b/src/harmaja.ts
@@ -162,17 +162,19 @@ function setProp(el: Element, key: string, value: any) {
         attachOnMount(el, () => refFn(el))
         return
     }
-    if (key.startsWith("on")) {
+    else if (key.startsWith("on")) {
         key = key.toLowerCase()
     }           
-    if (key === "style") {
+    else if (key === "style") {
         const styles = Object.entries(value)
             .filter(([key, value]) => key !== "")
             .map(([key, value]) => `${toKebabCase(key)}: ${value};`)
             .join("\n")
         el.setAttribute("style", styles)
+    } else if (key === "className") {
+        el.setAttribute("class", value)
     } else {
-        (el as any)[key] = value;
+        el.setAttribute(key, value)
     }
 }
 


### PR DESCRIPTION
Assigning a property to an element directly sets the
property as an attribute if it is a standard attribute
like "draggable". However, this is not the case for custom
attributes like "data-test".

By uniformly using element.setAttribute, the custom attributes
get inserted as DOM attributes as well.

Similarly, we can setAttribute("class") when the JSX key is
"className", to avoid the (el as any) type assertion.