### PR TITLE
Support nonstandard attributes, attempt 2

### DIFF
--- a/src/harmaja.test.tsx
+++ b/src/harmaja.test.tsx
@@ -26,6 +26,25 @@ describe("Harmaja", () => {
         expect(() => <span id="x" ref={"not-a-function" as any}/>).toThrow("Expecting ref prop to be a function, got not-a-function")
     })
 
+    it("Supports assigning standard and nonstandard attributes", () => {
+        let span = <span draggable={true} data-test="my-test-id">Hello</span>
+        mount(span, body())
+        expect(renderAsString(span)).toEqual('<span draggable="true" data-test="my-test-id">Hello</span>')
+    })
+
+    it("Event handlers get registered", () => {
+        let calls = 0
+        let span = <span onClick={() => {calls++ }}>Hello</span>
+
+        const mountedSpan = mount(span, body()) as HTMLSpanElement
+
+        expect(calls).toEqual(0)
+
+        mountedSpan.click()
+
+        expect(calls).toEqual(1)
+    })
+
     it("Creating elements with JSX", () => {
         const el = <h1>yes</h1>
         expect(renderAsString(el)).toEqual("<h1>yes</h1>")

--- a/src/harmaja.test.tsx
+++ b/src/harmaja.test.tsx
@@ -45,6 +45,19 @@ describe("Harmaja", () => {
         expect(calls).toEqual(1)
     })
 
+    it("Boolean props like disabled work", () => {
+        let calls = 0
+        let button = <button disabled={true} onClick={() => {calls++ }} />
+
+        const mountedButton = mount(button, body()) as HTMLButtonElement
+
+        expect(calls).toEqual(0)
+
+        mountedButton.click()
+
+        expect(calls).toEqual(0)
+    })
+
     it("Creating elements with JSX", () => {
         const el = <h1>yes</h1>
         expect(renderAsString(el)).toEqual("<h1>yes</h1>")

--- a/src/harmaja.ts
+++ b/src/harmaja.ts
@@ -162,17 +162,23 @@ function setProp(el: Element, key: string, value: any) {
         attachOnMount(el, () => refFn(el))
         return
     }
+
     if (key.startsWith("on")) {
-        key = key.toLowerCase()
-    }           
-    if (key === "style") {
+        key = key.toLowerCase();
+        (el as any)[key] = value
+    }
+    else if (key === "style") {
         const styles = Object.entries(value)
             .filter(([key, value]) => key !== "")
             .map(([key, value]) => `${toKebabCase(key)}: ${value};`)
             .join("\n")
         el.setAttribute("style", styles)
-    } else {
-        (el as any)[key] = value;
+    }
+    else if (key === "className") {
+        el.setAttribute("class", value)
+    }
+    else {
+        el.setAttribute(key, value)
     }
 }
 

--- a/src/harmaja.ts
+++ b/src/harmaja.ts
@@ -177,7 +177,9 @@ function setProp(el: Element, key: string, value: any) {
     else if (key === "className") {
         el.setAttribute("class", value)
     }
-    else {
+    else if (key in el) {
+        (el as any)[key] = value
+    } else {
         el.setAttribute(key, value)
     }
 }


### PR DESCRIPTION
#29 introduced a bug where props starting with "on",
ie event listeners, were never actually assigned to the
html element.