### PR TITLE
Support React-style short circuiting

### DIFF
--- a/src/harmaja.test.tsx
+++ b/src/harmaja.test.tsx
@@ -114,6 +114,11 @@ describe("Harmaja", () => {
         */
     })
 
+    it("Supports React-style short circuiting", () => {
+        expect(renderAsString(<h1>{true && <p>asdf</p>}</h1>)).toEqual(`<h1><p>asdf</p></h1>`)
+        expect(renderAsString(<h1>{false && <p>asdf</p>}</h1>)).toEqual(`<h1></h1>`)
+    })
+
     describe("Components", () => {
         it("Renders component children", () => {
             const C1 = ({children}:{children?:any}) => <div>{children}</div>

--- a/src/harmaja.ts
+++ b/src/harmaja.ts
@@ -123,7 +123,7 @@ function render(child: HarmajaChild | HarmajaOutput): HarmajaStaticOutput {
     if (typeof child === "string" || typeof child === "number") {
         return document.createTextNode(child.toString())
     }
-    if (child === null) {
+    if (child === null || child === false) {
         return createPlaceholder()
     }
     if (O.isProperty(child)) {


### PR DESCRIPTION
For convenience, allow rendering expressions like
isSelected && <SelectionIndicator />

using booleans as the first operand. This allows omitting
ternary expressions in common use cases.