### PR TITLE
Register doubleclick events correctly

### DIFF
--- a/src/harmaja.test.tsx
+++ b/src/harmaja.test.tsx
@@ -58,6 +58,20 @@ describe("Harmaja", () => {
         expect(calls).toEqual(0)
     })
 
+    it("Registers dblclick handler properly -- JSX attribute name is onDoubleClick, native property is ondblclick", () => {
+        let calls = 0
+        let button = <button disabled={true} onDoubleClick={() => {calls++ }} />
+
+        const mountedButton = mount(button, body()) as HTMLButtonElement
+
+        expect(calls).toEqual(0)
+
+        const clickEvent  = document.createEvent("MouseEvents")
+        clickEvent.initEvent("dblclick")
+        mountedButton.dispatchEvent(clickEvent)
+        expect(calls).toEqual(1)
+    })
+
     it("Creating elements with JSX", () => {
         const el = <h1>yes</h1>
         expect(renderAsString(el)).toEqual("<h1>yes</h1>")

--- a/src/harmaja.ts
+++ b/src/harmaja.ts
@@ -165,6 +165,7 @@ function setProp(el: Element, key: string, value: any) {
 
     if (key.startsWith("on")) {
         key = key.toLowerCase();
+        key = key === "ondoubleclick" ? "ondblclick" : key;
         (el as any)[key] = value
     }
     else if (key === "style") {


### PR DESCRIPTION
the JSX attribute for doubleclick event listeners is onDoubleClick,
but the native property is ondblclick, so making the onDoubleClick prop
work requires special handling for that particular case.

As far as I know, all other event types have a direct mapping from
camelcase to lowercase.