### PR TITLE
Use setAttribute for properties that are not writable

### DIFF
--- a/src/harmaja.test.tsx
+++ b/src/harmaja.test.tsx
@@ -45,6 +45,19 @@ describe("Harmaja", () => {
         expect(calls).toEqual(1)
     })
 
+    it("Can assign readonly props like select.form", () => {
+        const formAndSelect = <div><form id="test-form"></form><select form="test-form" /></div>
+
+        const mountedParentDiv = mount(formAndSelect, body()) as HTMLDivElement
+
+        const form = mountedParentDiv.querySelector("form")!
+        const select = mountedParentDiv.querySelector("select")!
+
+        expect(select.form).toBe(form)
+
+        expect(renderAsString(formAndSelect)).toEqual('<div><form id="test-form"></form><select form="test-form"></select></div>')
+    })
+
     it("Boolean props like disabled work", () => {
         let calls = 0
         let button = <button disabled={true} onClick={() => {calls++ }} />

--- a/src/harmaja.ts
+++ b/src/harmaja.ts
@@ -176,11 +176,20 @@ function setProp(el: Element, key: string, value: any) {
     }
     else if (key === "className") {
         el.setAttribute("class", value)
-    }
-    else if (key in el) {
-        (el as any)[key] = value
-    } else {
+    } else if (!(key in el)) {
         el.setAttribute(key, value)
+    } else {
+        let current = el
+        let descriptor: PropertyDescriptor | undefined = undefined
+        while (current && !descriptor) {
+            descriptor = Object.getOwnPropertyDescriptor(current, key)
+            current = Object.getPrototypeOf(current)
+        }
+        if (!descriptor || (!descriptor.writable && !descriptor.set)) {
+            el.setAttribute(key, value)
+        } else {
+            (el as any)[key] = value
+        }
     }
 }
 


### PR DESCRIPTION
Example case: setting the "form" property of a select element is not possible,
because the "form" property descriptor on select.__proto__ has no setter.
Instead, using setAttribute for these cases works.