### PR TITLE
Add support for the new jsx-runtime transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,11 @@ Tweak your tsconfig.json for the custom JSX factory.
 {
     "compilerOptions": {
         // ...
-        "jsx": "react",
-        "jsxFactory": "h"
+        "jsx": "react-jsx", // or react-jsxdev for dev mode builds
+        "jsxImportSource": "harmaja/lonna" // or harmaja/bacon or harmaja/rxjs if you are using bacon.js or rxjs respectively instead of lonna
     }
     // ...
 }
-```
-
-In your component code you'll need to import the `h` function from Harmaja like this, so that the TypeScript compiler can use it for creating DOM nodes when you use JSX.
-
-```typescript
-import { h } from "harmaja"
 ```
 
 Then you can start using JSX, creating your application components and mounting them to the DOM.
@@ -68,6 +62,25 @@ Then you can start using JSX, creating your application components and mounting 
 ```tsx
 const App = () => <h1>yes</h1>
 mount(<App />, document.getElementById("root")!)
+```
+
+If your build tool doesn't support the new `react-jsx` transform for JSX, you can use the old method:
+
+```jsonc
+{
+    "compilerOptions": {
+        // ...
+        "jsx": "react",
+        "jsxFactory": "h"
+    }
+    // ...
+}
+```
+
+When using the old transform, you'll need to import the `h` function from Harmaja in any files that use JSX, so that the TypeScript compiler can use it for creating DOM nodes.
+
+```typescript
+import { h } from "harmaja"
 ```
 
 ## Observable Library Selection

--- a/package.json
+++ b/package.json
@@ -2,6 +2,20 @@
   "name": "harmaja",
   "version": "0.23.0",
   "main": "lonna/index.js",
+  "exports": {
+    ".": "lonna/index.js",
+    "./jsx-runtime": "lonna/jsx-runtime.js",
+    "./jsx-dev-runtime": "lonna/jsx-dev-runtime.js",
+    "./lonna": "lonna/index.js",
+    "./lonna/jsx-runtime": "lonna/jsx-runtime.js",
+    "./lonna/jsx-dev-runtime": "lonna/jsx-dev-runtime.js",
+    "./bacon": "bacon/index.js",
+    "./bacon/jsx-runtime": "bacon/jsx-runtime.js",
+    "./bacon/jsx-dev-runtime": "bacon/jsx-dev-runtime.js",
+    "./rxjs": "rxjs/index.js",
+    "./rxjs/jsx-runtime": "rxjs/jsx-runtime.js",
+    "./rxjs/jsx-dev-runtime": "rxjs/jsx-dev-runtime.js"
+  },
   "types": "lonna/index.d.ts",
   "license": "MIT",
   "devDependencies": {

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,0 +1,16 @@
+import { JSXElementType, HarmajaProps, HarmajaOutput } from "./harmaja"
+import { jsx } from "./jsx-runtime"
+
+export { Fragment } from "./harmaja"
+
+// This is the jsx entrypoint when using the development mode transform, i.e. `react-jsxdev` in tsconfig
+export function jsxDEV(
+    type: JSXElementType,
+    props: HarmajaProps,
+    maybeKey?: string,
+    isStaticChildren?: boolean,
+    source?: string,
+    self?: string
+): HarmajaOutput {
+    return jsx(type, props, maybeKey)
+}

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,39 @@
+import {
+    createElement,
+    JSXElementType,
+    HarmajaProps,
+    HarmajaOutput,
+} from "./harmaja"
+
+export { Fragment } from "./harmaja"
+
+// the jsx function is called when the children prop is a dynamically created array:
+// <div>
+//   { someArray.map(() => <div />) }
+// </div>
+export function jsx(
+    type: JSXElementType,
+    props: HarmajaProps,
+    maybeKey?: string
+): HarmajaOutput {
+    const { children, ...otherProps } = props
+    if (maybeKey !== undefined) {
+        otherProps.key = maybeKey
+    }
+    return children !== undefined
+        ? createElement(type, otherProps, ...children)
+        : createElement(type, otherProps)
+}
+
+// the jsxs function is called when the children prop is a static array, i.e. when you just provide multiple jsx children:
+// <div>
+//   <div />
+//   <div />
+// </div
+export function jsxs(
+    type: JSXElementType,
+    props: HarmajaProps,
+    maybeKey?: string
+): HarmajaOutput {
+    return jsx(type, props, maybeKey)
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,5 @@
         "declaration": true,
         "sourceMap": true
     },
-    "include": ["src/index.ts"]
+    "include": ["src/index.ts", "src/jsx-runtime.ts", "src/jsx-dev-runtime.ts"]
 }


### PR DESCRIPTION
Implements the new style JSX factories for the new jsx runtime transform. This enables the use of JSX without importing `h` everywhere. That's basically the biggest impact of this at the moment.

The implementation is just a couple of wrappers for the existing `createElement` just so that we gain support for them, but they could be improved to make use of the improvements brought by the new interfaces. Something to look into in the future.

closes https://github.com/raimohanska/harmaja/issues/28, although it doesn't help with the JSX typing issue mentioned there

Sadly, this cannot be used for ourboard, since esbuild doesn't have support for the new transform yet